### PR TITLE
Fix typo

### DIFF
--- a/books/bookvol0.pamphlet
+++ b/books/bookvol0.pamphlet
@@ -10231,7 +10231,7 @@ To turn on \TeX{} output formatting, issue this.
 
 Here is an example of its output.
 \begin{verbatim}
-matrix [ [i*x**i + j*\%i*y**j for i in 1..2] for j in 3..4]
+matrix [ [i*x**i + j*%i*y**j for i in 1..2] for j in 3..4]
 
 $$
 \left[


### PR DESCRIPTION
There's no needs to escape `%` in verbatim env.