### PR TITLE
Fix src/Makefile being wrongly overwritten by src/sman/Makefile

### DIFF
--- a/src/Makefile.pamphlet
+++ b/src/Makefile.pamphlet
@@ -49,9 +49,10 @@ processes including axiom, clef, nagman, graphics, and hyperdoc
 \begin{chunk}{smandir}
 smandir: ${SPD}/books/bookvol6.pamphlet
 	@echo 5 making ${SRC}/sman
-	@( cd sman ; \
+	@( mkdir -p sman ; \
+	   cd sman ; \
 	   ${BOOKS}/tanglec ${BOOKS}/bookvol6.pamphlet >Makefile ; \
-           ${ENV} ${MAKE} )
+	   ${ENV} ${MAKE} )
 
 \end{chunk}
 \subsection{The share directory}
@@ -67,8 +68,8 @@ ${SRC}/share/Makefile: ${SRC}/share/Makefile.pamphlet
 	@echo 10 making ${SRC}/share/Makefile from \
            ${SRC}/share/Makefile.pamphlet
 	@( cd share ; \
-           ${EXTRACT} Makefile ; \
-           cp Makefile.pdf ${MNT}/${SYS}/doc/src/share.Makefile.pdf )
+	   ${EXTRACT} Makefile ; \
+	   cp Makefile.pdf ${MNT}/${SYS}/doc/src/share.Makefile.pdf )
 
 sharedocument: ${SRC}/share/Makefile
 	@echo 11 documenting ${SRC}/share


### PR DESCRIPTION
In `src/Makefile.pamphlet`, the following chunk of code extracts another `Makefile` from `bookvol6.pamphlet` into `src/sman` and execute the new Makefile for building some executions (`spadclient`, `session`, etc.):

```
\begin{chunk}{smandir}
smandir: ${SPD}/books/bookvol6.pamphlet
	@echo 5 making ${SRC}/sman
	@( cd sman ; \
	   ${BOOKS}/tanglec ${BOOKS}/bookvol6.pamphlet >Makefile ; \
	   ${ENV} ${MAKE} )

\end{chunk}
```

Unfortunately, the command `cd sman` failed, because the sub-directory `src/sman` doesn't exist. But this is not a fetal issue, as the next shell commands still successfully extracted the new Makefile and execute it, just it is directly put into `src/` and overwrote the existing one.  The final resulting Axion build didn't miss anything which should be built but not, just the toplevel platform-specific `Makefile.SYS` now becomes invalid, because the calling `src/Makefile` is not the correct one.  A simple solution is to do `mkdir -p sman` before `cd sman`.
