### PR TITLE
Fixed prompt repeating due to GCL's own readline enabled by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,8 @@ BYE:=bye
 GCLVERSION=gcl-2.6.12
 #GCLVERSION=gcl-2.6.13pre
 GCLDIR:=${LSP}/${GCLVERSION}
-GCLOPTS="--enable-vssize=65536*2 --disable-xgcl --disable-tkconfig"
+GCLOPTS="--enable-vssize=65536*2 --disable-xgcl --disable-tkconfig \
+         --disable-tclconfig --disable-readline"
 LISP:=lsp
 
 ##### command line control

--- a/Makefile.pamphlet
+++ b/Makefile.pamphlet
@@ -922,7 +922,8 @@ to system. We create an environment variable here so we can add options
 to the configure command in the lsp/Makefile.pamphlet.
 
 \begin{chunk}{GCLOPTS} 
-GCLOPTS="--enable-vssize=65536*2 --disable-xgcl --disable-tkconfig"
+GCLOPTS="--enable-vssize=65536*2 --disable-xgcl --disable-tkconfig \
+         --disable-tclconfig --disable-readline"
 \end{chunk}
 It turns out that we can successfully build GCL on many more systems
 if we set the GCLOPTS to build a local BFD.


### PR DESCRIPTION
Hi,

Currently all Axiom commands are repeated after hitting enter, e.g. below is some usage of August 2014 binary release:

```
This function is obsolete -- use SET-STARTING-HOLE-DIVISOR instead
                        AXIOM Computer Algebra System 
                        Version: Axiom (August 2014)
                Timestamp: Monday July 28, 2014 at 04:12:34 
-----------------------------------------------------------------------------
   Issue )copyright to view copyright notices.
   Issue )summary for a summary of useful system commands.
   Issue )quit to leave AXIOM and return to shell.
   Visit http://axiom-developer.org for more information
-----------------------------------------------------------------------------
 
   Re-reading interp.daase
   Re-reading operation.daase
   Re-reading category.daase
   Re-reading browse.daase
(1) -> 
(1) -> 0
(1) -> 
   (1)  0
                                                     Type: NonNegativeInteger
(2) -> 1
1
(2) -> 
   (2)  1
                                                        Type: PositiveInteger
(3) -> integrate(x^2,x)
integrate(x^2,x)
(3) -> 
        1  3
   (3)  - x
        3
                                          Type: Polynomial(Fraction(Integer))
(4) -> )quit
)quit
   Please enter y or yes if you really want to leave the interactive 
      environment and return to the operating system:
y
y
```

I found that this issue has a simple root cause: when building GNU Common Lisp, it has linked with `libreadline` by default and GNU's own command line editing is disturbing Axiom's own `clef` facility, causing the whole issue.

The simple solution is to disable readline when building GCL.  (This also makes the Linux binary release run on more distribution, because different Linux has different versions of libreadline.) Below is a new sample usage (on Mac OS X) after applying my patch:

```
                        AXIOM Computer Algebra System
                          Version: Axiom (May 2017)
               Timestamp: Thursday June 30, 2022 at 10:59:57 
-----------------------------------------------------------------------------
   Issue )copyright to view copyright notices.
   Issue )summary for a summary of useful system commands.
   Issue )quit to leave AXIOM and return to shell.
   Visit http://axiom-developer.org for more information
-----------------------------------------------------------------------------
 
   Re-reading interp.daase
   Re-reading operation.daase
   Re-reading category.daase
   Re-reading browse.daase
(1) -> 
(1) -> 0                  

   (1)  0
                                                     Type: NonNegativeInteger
(2) -> integrate(x^2,x)

        1  3
   (2)  - x
        3
                                          Type: Polynomial(Fraction(Integer))
(3) -> 
```

Regards,

Chun Tian